### PR TITLE
Fix directory name in setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 build/
 dist/
-pulsarpy-to-encodedcc.egg-info/
+pulsarpy_to_encodedcc.egg-info/
 .nfs*
 *.pyc
 *.txt

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import glob
 import os
 from setuptools import setup, find_packages
 
-SCRIPTS_DIR = "pulsarpy_to_dcc/scripts/"
+SCRIPTS_DIR = "pulsarpy_to_encodedcc/scripts/"
 scripts = glob.glob(os.path.join(SCRIPTS_DIR,"*.py"))
 scripts.remove(os.path.join(SCRIPTS_DIR,"__init__.py"))
 


### PR DESCRIPTION
Setup failed due to wrong script directory name as
```
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/yunhailuo/Github/pulsarpy-to-encodedcc/setup.py", line 23, in <module>
        scripts.remove(os.path.join(SCRIPTS_DIR,"__init__.py"))
    ValueError: list.remove(x): x not in list
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```
